### PR TITLE
Python to C via Cython

### DIFF
--- a/python_to_c/README.md
+++ b/python_to_c/README.md
@@ -1,0 +1,20 @@
+# Build & Run
+
+Cython takes python-like code and compiles it to C code. It does this using a special syntax. Inside `hello.pyx` you will see some functions and variables declared with the `cdef` keyword; `cdef` tells Cython that these functions and variables are C functions and variables, not python ones. Cython is powerful because it lets you take an existing python function and, with a few minor tweaks, compile it to C.
+
+To build the C code, run `python3 setup.py build_ext --inplace`. That's it! If you didn't get any error messages, you can now run `python3 main.py` and see the expected output!
+
+# Notes
+
+* `hello.pyx` contains functions written in python, but modified to use the `cdef` keyword.
+* `setup.py` runs a few commands to tell Cython to compile your C code. It will install Cython for you if you don't have it installed already. You will need `sudo` for this.
+* `hello.c` is one of the files that gets created when you run `setup.py`. It contains all of the C code that you would have had to write in order to do what Cython does for you. Take a look at the code and imagine how much time you just saved!
+* `hello.so` is the other file created by `setup.py`. You should notice that this file is an executable which contains dynamic libraries.
+
+# Resources
+These are helpful sites to guide you through what's happening here:
+
+* [Cython Documentation](http://cython.org/)
+* [Python Docs on setup.py](https://docs.python.org/3.5/distutils/setupscript.html)
+* [Python Docs on Extensions](https://docs.python.org/3.5/distutils/setupscript.html#extension-source-files)
+* [Hello World! in Cython](http://cython.readthedocs.io/en/latest/src/tutorial/cython_tutorial.html)

--- a/python_to_c/hello.pyx
+++ b/python_to_c/hello.pyx
@@ -1,0 +1,19 @@
+from libc.stdio cimport printf
+
+cdef void c_say_hello():
+    cdef char *str = "Hello, World!";
+    printf("%s\n", str);
+
+def say_hello():
+    c_say_hello();
+
+cdef int c_multiply(int py_x, int py_y):
+    cdef int x = py_x;
+    cdef int y = py_y;
+
+    cdef product = x * y;
+
+    return product;
+
+def multiply(py_x, py_y):
+    return c_multiply(py_x, py_y);

--- a/python_to_c/main.py
+++ b/python_to_c/main.py
@@ -1,0 +1,11 @@
+import hello
+
+print("\n--- Example C Bindings Test ---")
+
+print(">> About to call say_hello()")
+hello.say_hello()
+
+print(">> Call multiply(4,5)")
+print(hello.multiply(4, 5))
+
+print("^^ Was that 20? Then it worked!")

--- a/python_to_c/setup.py
+++ b/python_to_c/setup.py
@@ -1,0 +1,23 @@
+import fnmatch
+import os
+import pip
+import shutil
+
+try:
+    from Cython.Build import cythonize
+except:
+    pip.main(["install", "Cython"])
+    from Cython.Build import cythonize
+
+
+from distutils.core import setup
+from distutils.extension import Extension
+
+setup(
+    ext_modules = cythonize([Extension("hello", ["hello.pyx"])]),
+)
+
+shutil.rmtree("./build/")
+for f in os.listdir("."):
+    if fnmatch.fnmatch(f, "hello.*.so"):
+        os.rename(f, "hello.so")


### PR DESCRIPTION
This doesn't work in nitron's native environment (because we don't have access to the system-wide `pip` to install Cython), but it does run in a python `venv`:

```
    # Create the venv
    python3.6 -m venv /home/abc1234/some_directory/
    # Run the code
    /home/abc1234/some_directory/bin/python3.6 setup.py build_ext --inplace
    /home/abc1234/some_directory/bin/python3.6 main.py
```