### PR TITLE
Created Python to C example without Cython

### DIFF
--- a/python_to_c_no_cython/README.md
+++ b/python_to_c_no_cython/README.md
@@ -1,0 +1,47 @@
+# Binding C to Python without Cython
+
+This method follows the turorial on [this page](https://docs.python.org/3/extending/extending.html) to create a Python module that can be imported in Python. The build produces a .so file that can be installed in a python install (therefore it might not work on Nitron, sorry :/)
+
+## Dependencies
+
+Python 3
+
+```
+$ sudo apt install python3
+```
+
+Make
+
+```
+$ sudo apt install make
+```
+
+Python3 Development pacakge
+
+```
+$ sudo apt install python3-dev
+```
+
+## Running
+
+To run this example, simply run. 
+
+```
+$ make
+$ sudo make install
+$ python3 run.py
+```
+
+For details about the build process, check out these docs:
+
+* [Building on Linux](https://docs.python.org/3/extending/building.html#building)
+* [Building on Windows](https://docs.python.org/3/extending/windows.html#building-on-windows)
+
+## Implementation Details
+
+`cModule.c` has comments explaining every step to write a function in C, and define a module that can be compiled for Python.
+
+`setup.py` contains the code to compile the module.
+
+`run.py` demonstrates how to use the module.
+

--- a/python_to_c_no_cython/cModule.c
+++ b/python_to_c_no_cython/cModule.c
@@ -1,0 +1,63 @@
+// on linux run 
+// sudo apt install python3-dev 
+// to get Python.h
+#include <Python.h>
+
+// All functions take this signature
+PyObject * power (PyObject *self, PyObject *args) {
+    int a, b; // Declare any variables you want to take as input parameters
+
+    // PyArg_ParseTuple takes your args(which is a tuple) and splits it into
+    // your input parameters. The second parameter is the types, in this case
+    // i means int, so ii means two integers. Everything after the colon is used
+    // when reporting any exceptions. An additional parameters are the addresses
+    // where you want your parameters stored
+    if (!PyArg_ParseTuple(args, "ii:power", &a, &b))
+        // Returing NULL reports an exception has ocurred
+        return NULL;
+
+    // Code your function
+    int result = 1;
+    if (b > 0) {
+        int i;
+        for (i = 0; i < b; i++) {
+            result = result * a;
+        }
+    }
+    
+    // Convert your answer into a PyObject
+    return PyLong_FromLong(result);    
+}
+
+// Define the method table. This is an array of structs with the format
+// - String method name in python
+// - function pointer to c function
+// - METH_VARARGS to specify how the args is passed into the function
+// - String holding documentation for IDEs
+// The last element in the array MUST be {NULL, NULL, 0, NULL}
+static PyMethodDef PythonToCMethods[] = {
+    { "power", power, METH_VARARGS, "Raise a to the power b" },
+    { NULL, NULL, 0, NULL}
+};
+
+// Define the module definition structure
+// The first element of the struct is necessary for standalone modules
+// The second is the module name
+// The third is for module documentation. I use NULL since I don't have any docs
+// The fourth holds the module state. -1 if the state is kept in global variables
+// The last is a reference to the method table from above
+static struct PyModuleDef pythonToCExampleModule = {
+    PyModuleDef_HEAD_INIT,
+    "pythonToCExample",
+    NULL,
+    -1,
+    PythonToCMethods
+};
+
+// This function is called when the module is initialized. The function name
+// MUST be PyInit_<<module name>>(void)
+PyMODINIT_FUNC
+PyInit_pythonToCExample(void) {
+    return PyModule_Create(&pythonToCExampleModule);
+}
+

--- a/python_to_c_no_cython/makefile
+++ b/python_to_c_no_cython/makefile
@@ -1,0 +1,13 @@
+# builds the module
+target: setup.py cModule.c
+	python3 setup.py build
+
+# installs the module
+# NOTE: Might need to be run as root
+install:
+	python3 setup.py install
+
+# cleans up the build
+clean:
+	rm -r build
+

--- a/python_to_c_no_cython/run.py
+++ b/python_to_c_no_cython/run.py
@@ -1,0 +1,3 @@
+import pythonToCExample as p2c
+
+print(p2c.power(2,4))

--- a/python_to_c_no_cython/setup.py
+++ b/python_to_c_no_cython/setup.py
@@ -1,0 +1,10 @@
+from distutils.core import setup, Extension
+
+pythonToCExample = Extension('pythonToCExample',
+                    sources = ['cModule.c'])
+
+setup (name = 'PythonToCExample',
+       version = '1.0',
+       description = 'Native Bindings Lab',
+       ext_modules = [pythonToCExample])
+


### PR DESCRIPTION
This Pull Request creates an example that can be used on a linux machine to create a Python module using C. It also documents where more information can be found to create more complicated modules. 